### PR TITLE
Change NPM commands in package.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint && npm run prettier
 
       - name: Execute integration test
-        run: npm run test
+        run: npm run test:ci
 
   build-full-ingestion:
     name: Build the application for full-ingestion
@@ -64,4 +64,4 @@ jobs:
         run: npm run lint && npm run prettier
 
       - name: Execute integration test
-        run: npm run test
+        run: npm run test:ci

--- a/full-ingestion/package.json
+++ b/full-ingestion/package.json
@@ -9,8 +9,8 @@
     "start:dev": "node_modules/.bin/nodemon -q src/index.js",
     "lint": "node_modules/.bin/eslint src --ext .js",
     "prettier": "node_modules/.bin/prettier --write '**/*.{js,ts}'",
-    "test": "node_modules/.bin/jest --config jest.config.cjs",
-    "test:watch": "node_modules/.bin/jest --watch"
+    "test": "echo Comment: It is npm command dedicated for running test in connect service",
+    "test:ci": "node_modules/.bin/jest --config jest.config.cjs"
   },
   "author": "",
   "license": "MIT",

--- a/incremental-updater/package.json
+++ b/incremental-updater/package.json
@@ -9,8 +9,8 @@
     "start:dev": "node_modules/.bin/nodemon -q src/index.js",
     "lint": "node_modules/.bin/eslint src --ext .js",
     "prettier": "node_modules/.bin/prettier --write '**/*.{js,ts}'",
-    "test": "node_modules/.bin/jest --config jest.config.cjs",
-    "test:watch": "node_modules/.bin/jest --watch",
+    "test": "echo Comment: It is npm command dedicated for running test in connect service",
+    "test:ci": "node_modules/.bin/jest --config jest.config.cjs",
     "connector:post-deploy": "node src/connectors/post-deploy.js",
     "connector:pre-undeploy": "node src/connectors/pre-undeploy.js"
   },


### PR DESCRIPTION
- Since connect service would run `npm run test` implicitly during deployment without assigning environment variables, it is necessary to avoid running the integration test in `npm run test` command. Therefore we split the integration test into another npm command which is triggered only in Github CI, so that connect service would not execute the integration test with absent environment variables and cause error.